### PR TITLE
Update CMakeLists.txt project name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
-project(pocketsphinx)
+project(cmu_pocketsphinx)
 
 find_package(catkin REQUIRED)
 catkin_package(DEPENDS)


### PR DESCRIPTION
The package failed to be built after cloning it in my workspace. This is because the project names in the package.xml and CMakeLists.txt files are not the same. The project name in package.xml is (cmu_pocketsphinx) while in the CMakeLists.txt file the name is (pocketsphinx). Both names must be identical.